### PR TITLE
feat:  filtering conditions as implemented in the R 'bubble' package …

### DIFF
--- a/lppls/lppls.py
+++ b/lppls/lppls.py
@@ -351,7 +351,12 @@ class LPPLS(object):
             tc_in_range = last - tc_init_min < tc < last + tc_init_max
             m_in_range = 0.01 < m < 1.2
             w_in_range = 2 < w < 25
-            n_oscillation = ((w / 2) * np.log(abs((tc - first) / (last - first)))) > 2.5
+
+            # n_oscillation = ((w / 2) * np.log(abs((tc - first) / (last - first)))) > 2.5
+            # Use filtering conditions as implemented in the R 'bubble' package by Dean Fantazzini
+            # (https://github.com/Boulder-Investment-Technologies/lppls/issues/url)
+            n_oscillation = ((w / 2 * np.pi) * np.log(abs((tc) / (tc - last)))) > 2.5
+
             # for bubble end flag
             damping_bef = (m * abs(b)) / (w * abs(c)) > 0.8
             # for bubble early warning

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(name='lppls',
-      version='0.2.2',
+      version='0.2.3',
       description='A Python module for fitting the LPPLS model to data.',
       packages=['lppls'],
       author='Josh Nielsen',


### PR DESCRIPTION
…by Dean Fantazzini

The computation of the number of oscillations cited in the reference papers. from Sornette et. al.

n_oscillation = ((w / 2) * np.log(abs((tc - first) / (last - first)))) > 2.5

almost never evaluates to true.  Using the filtering conditions for the confidence indicator as implemented in the R bubble package by Dean Fantazzini (https://github.com/deanfantazzini/bubble/blob/master/R/LPPL_confidence.R) , which is:

n_oscillation = w /( 2 * math.pi) * np.log(abs(tc / (tc - last))) > 2.5

yield more reasonable results (in line with the visual depiction of the fit).

Resolves: #12