### PR TITLE
Added Continuous Integration

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -5,8 +5,6 @@ jobs:
   githubActionForPytest:
     name: GitHub Action for pytest
     runs-on: ubuntu-latest
-    
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -13,10 +13,11 @@ jobs:
         python-version: '3.x'
     - name: Install dependencies  
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt
+        pip install --upgrade pip
+        pip install setuptools wheel
+        pip install -r requirements.txt
         
     - name: Run Pytest
       run: |
-        python -m pip install pytest
+        pip install pytest
         pytest

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -7,11 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
     - name: Install dependencies  
       run: |
         python -m pip install --upgrade pip
-        python -m pip install setuptools wheel twine
         python -m pip install -r requirements.txt
         
     - name: Run Pytest

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,12 +1,20 @@
+
 on: push
-name: on push
+name: Continuous Integration
 jobs:
-  gitHubActionForPytest:
+  githubActionForPytest:
     name: GitHub Action for pytest
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: GitHub Action for pytest
-      uses: cclauss/GitHub-Action-for-pytest@master
-      with:
-        args: pip3 install -r sys/requirements_conda.txt && pytest
+    - uses: actions/checkout@v2
+    
+    - name: Install dependencies  
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+        python setup.py sdist bdist_wheel
+        
+    - name: Run Pytest
+      run: |
+        pip install pytest
+        pytest

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.x'
+        python-version: '3.6'
     - name: Install dependencies  
       run: |
         pip install --upgrade pip

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,0 +1,12 @@
+on: push
+name: on push
+jobs:
+  gitHubActionForPytest:
+    name: GitHub Action for pytest
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: GitHub Action for pytest
+      uses: cclauss/GitHub-Action-for-pytest@master
+      with:
+        args: pip3 install -r sys/requirements_conda.txt && pytest

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -11,10 +11,10 @@ jobs:
     - name: Install dependencies  
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-        python setup.py sdist bdist_wheel
+        python -m pip install setuptools wheel twine
+        python -m pip install -r requirements.txt
         
     - name: Run Pytest
       run: |
-        pip install pytest
+        python -m pip install pytest
         pytest

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -5,12 +5,18 @@ jobs:
   githubActionForPytest:
     name: GitHub Action for pytest
     runs-on: ubuntu-latest
+    
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
-        python-version: '3.6'
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies  
       run: |
         pip install --upgrade pip

--- a/lppls/lppls.py
+++ b/lppls/lppls.py
@@ -12,8 +12,12 @@ class LPPLS(object):
         """
         Args:
             use_ln (bool): Whether to take the natural logarithm of the observations.
-            observations (np.array): 2xM matrix with timestamp and observed value.
+            observations (np.array,pd.DataFrame): 2xM matrix with timestamp and observed value.
         """
+        assert isinstance(use_ln, bool), f'Expected use_ln to be <bool>, got :{type(use_ln)}'
+        assert isinstance(observations, (np.ndarray,pd.DataFrame)), \
+            f'Expected observations to be <pd.DataFrame> or <np.array>, got :{type(use_ln)}'
+
         self.use_ln = use_ln
         self.observations = observations
 
@@ -25,7 +29,7 @@ class LPPLS(object):
 
     def func_restricted(self, x, *args):
         '''
-        finds the least square difference
+        Finds the least square difference.
         '''
         tc = x[0]
         m = x[1]
@@ -49,7 +53,7 @@ class LPPLS(object):
 
     def matrix_equation(self, observations, tc, m, w):
         '''
-            Derive linear parameters in LPPLs from nonlinear ones.
+        Derive linear parameters in LPPLs from nonlinear ones.
         '''
         T = observations[0]
         P = np.log(observations[1]) if self.use_ln else observations[1]

--- a/lppls/tests/test_data_loader.py
+++ b/lppls/tests/test_data_loader.py
@@ -1,0 +1,11 @@
+import data_loader
+import pandas as pd
+
+
+def test_sp500():
+    # Test that stream loads
+    data = data_loader.sp500()
+    assert data.iloc[0].values.tolist() == ['2013-10-30', 1772.27002, 1775.219971, 1757.2399899999998, 1763.310059,
+                                          1763.310059, 3523040000]
+
+

--- a/lppls/tests/test_lppls.py
+++ b/lppls/tests/test_lppls.py
@@ -29,14 +29,15 @@ def test_lppls(data):
     assert 7.6306097488441615 == lppls_model.lppls(t, tc, m, w, a, b, c1, c2)
 
     # Not using ln
+    lppls_model = lppls.LPPLS(use_ln=False, observations=data)
     # Check integrity at period 0
     t, tc, m, w, a, b, c1, c2 = 0.0, 1300.2412888852296, 0.6087189222292106, 6.344318139503496, 3034.166016949172,\
                                 - 16.041970137173486, 0.21878280136703082, - 0.14789336333436504
-    assert 1762.3196588471408 == lppls_model.lppls(t, tc, m, w, a, b, c1, c2)
+    assert 1793.5438277142375 == lppls_model.lppls(t, tc, m, w, a, b, c1, c2)
 
     # Check integrity at period 500
     t, tc, m, w, a, b, c1, c2 = 500.0, 1428.0641475858731, 0.3473013071950998, 6.052643019980449, 3910.1099206097356,\
                                 -169.93053270790418, 0.05189394517600043, -0.045820295077658835
-    assert 2086.3299554496016 == lppls_model.lppls(t, tc, m, w, a, b, c1, c2)
+    assert 2087.089947771132 == lppls_model.lppls(t, tc, m, w, a, b, c1, c2)
 
     return

--- a/lppls/tests/test_lppls.py
+++ b/lppls/tests/test_lppls.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import lppls
+import data_loader
+import pytest
+
+@pytest.fixture
+def data():
+    return data_loader.sp500()
+
+def lppls_model():
+    """Returns a model instance with use_ln=True"""
+    return lppls.LPPLS(use_ln=True, observations=data_loader.sp500())
+
+def test_lppls(data):
+    # Test that the base lppls function is giving expected results.
+    lppls_model = lppls.LPPLS(use_ln=True,observations=data)
+
+    # Using ln
+    # Check integrity at period 0
+    t, tc, m, w, a, b, c1, c2 = 0.0, 1279.0429001048128, 0.2133326239108304, 11.091557842299654, 8.496823547814529,\
+                                -0.20816240802471664, 0.00478771542574161, 0.002854567990966797
+    assert 7.514469730428095 == lppls_model.lppls(t, tc, m, w, a, b, c1, c2)
+
+    # Check integrity at period 500
+    t, tc, m, w, a, b, c1, c2 = 500.0, 1267.9408517287782, 0.2782773005077447, 8.48668944887598, 8.314317740049685,\
+                                -0.10736015203099668, 0.0006372137521824459, 0.005475817732843753
+    assert 7.6306097488441615 == lppls_model.lppls(t, tc, m, w, a, b, c1, c2)
+
+    # Not using ln
+    # Check integrity at period 0
+    t, tc, m, w, a, b, c1, c2 = 0.0, 1300.2412888852296, 0.6087189222292106, 6.344318139503496, 3034.166016949172,\
+                                - 16.041970137173486, 0.21878280136703082, - 0.14789336333436504
+    assert 1762.3196588471408 == lppls_model.lppls(t, tc, m, w, a, b, c1, c2)
+
+    # Check integrity at period 500
+    t, tc, m, w, a, b, c1, c2 = 500.0, 1428.0641475858731, 0.3473013071950998, 6.052643019980449, 3910.1099206097356,\
+                                -169.93053270790418, 0.05189394517600043, -0.045820295077658835
+    assert 2086.3299554496016 == lppls_model.lppls(t, tc, m, w, a, b, c1, c2)
+
+    return

--- a/lppls/tests/test_lppls.py
+++ b/lppls/tests/test_lppls.py
@@ -8,6 +8,7 @@ import pytest
 def data():
     return data_loader.sp500()
 
+@pytest.fixture
 def lppls_model():
     """Returns a model instance with use_ln=True"""
     return lppls.LPPLS(use_ln=True, observations=data_loader.sp500())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+pandas==0.25.0
 matplotlib==3.1.1
 numpy==1.17.0
-pandas==0.25.0
 scipy==1.3.0
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ matplotlib==3.1.1
 numpy==1.17.0
 pandas==0.25.0
 scipy==1.3.0
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-pandas==0.25.0
 matplotlib==3.1.1
 numpy==1.17.0
+pandas==0.25.0
 scipy==1.3.0
-pytest


### PR DESCRIPTION
I'm going to delete my other pull request because this one is more complete.

- Added sample unittests.
- Tests passed for E(p(t)) function.
- Added pytest workflow for continuous integration.
- Discovered that the current requirements.txt will not work for all recent python versions. Tests pass on 3.6. 
- TODO: Add a matrix test strategy for >=3.6


If you are comfortable with how these initial unit tests are structured, I would like to build more.

How do you feel about decoupling some functions from the main LPPLS class? Currently, a set of observations must be loaded prior to running any functions. This can make it a bit trickier to isolate a function's reliability.

For instance:
lppls(self, t, tc, m, w, a, b, c1, c2) could be changed to lppls(t, tc, m, w, a, b, c1, c2,use_ln=True) and could be moved to outside the class, which would improve testing speeds by >1000x.