### PR TITLE
Adjusted requirements.txt so it builds on py38

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib==3.1.1
-numpy==1.17.0
-pandas==0.25.0
-scipy==1.3.0
+matplotlib>=3.1.1
+numpy>=1.17.0
+pandas>=0.25.0
+scipy>=1.3.0


### PR DESCRIPTION
Changed requirement.txt so dependencies can be flexibly solved for python 3.8.

Previously, `pip install -r requirements.txt` would not fail on 3.8.