### PR TITLE
feat: implement configurable filter_conditions_config for indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,14 @@ res = lppls_model.mp_compute_nested_fits(
     outer_increment=1, 
     inner_increment=5, 
     max_searches=25,
-    # filter_conditions_config={} # not implemented in 0.6.x
+    filter_conditions_config={
+        "m_min": 0.0,
+        "m_max": 1.0,
+        "w_min": 2.0,
+        "w_max": 15.0,
+        "O_min": 2.5,
+        "D_min": 0.5,
+    },
 )
 
 lppls_model.plot_confidence_indicators(res)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="lppls",
-    version="0.6.23",
+    version="0.6.24",
     description="A Python module for fitting the LPPLS model to data.",
     package_dir={"": "src"},
     packages=["lppls"],

--- a/src/lppls/lppls.py
+++ b/src/lppls/lppls.py
@@ -29,6 +29,54 @@ class LPPLS:
         self.observations: np.ndarray | pd.DataFrame = observations
         self.coef_: dict[str, float] = {}
         self.indicator_result: list[dict[str, Any]] = []
+        self.filter_conditions_config: dict[str, float] | None = None
+
+    @staticmethod
+    def _resolve_filter_conditions_config(
+        filter_conditions_config: dict[str, Any] | None,
+    ) -> dict[str, float]:
+        """Validate and merge filter condition thresholds for indicators."""
+        defaults: dict[str, float] = {
+            "m_min": 0.0,
+            "m_max": 1.0,
+            "w_min": 2.0,
+            "w_max": 15.0,
+            "O_min": 2.5,
+            "D_min": 0.5,
+            "tc_min_days": 60.0,
+            "tc_max_days": 252.0,
+            "tc_min_frac": 0.5,
+            "tc_max_frac": 0.5,
+        }
+        if filter_conditions_config is None:
+            return defaults
+
+        if not isinstance(filter_conditions_config, dict):
+            raise TypeError(
+                "filter_conditions_config must be a dict[str, float] or None."
+            )
+
+        unknown_keys = set(filter_conditions_config.keys()) - set(defaults.keys())
+        if unknown_keys:
+            raise ValueError(
+                "Unknown filter condition keys: "
+                f"{sorted(unknown_keys)}. Supported keys: {sorted(defaults.keys())}."
+            )
+
+        resolved = defaults.copy()
+        for key, value in filter_conditions_config.items():
+            resolved[key] = float(value)
+
+        if resolved["m_min"] >= resolved["m_max"]:
+            raise ValueError("m_min must be < m_max.")
+        if resolved["w_min"] >= resolved["w_max"]:
+            raise ValueError("w_min must be < w_max.")
+        if resolved["tc_min_days"] < 0 or resolved["tc_max_days"] < 0:
+            raise ValueError("tc_min_days and tc_max_days must be >= 0.")
+        if resolved["tc_min_frac"] < 0 or resolved["tc_max_frac"] < 0:
+            raise ValueError("tc_min_frac and tc_max_frac must be >= 0.")
+
+        return resolved
 
     @staticmethod
     @njit
@@ -276,12 +324,21 @@ class LPPLS:
                 mp_compute_nested_fits. Each element is a dict with keys
                 't2', 'p2', and 'res' (a list of individual fit dicts).
             filter_conditions_config (dict, optional): Custom filter
-                thresholds. Not yet implemented; when None, the following
-                defaults are used:
-                  - m: (0.0, 1.0)
-                  - w: (2.0, 15.0)
-                  - O (oscillations): > 2.5
-                  - D (damping): > 0.5
+                thresholds. Supported keys:
+                  - m_min, m_max
+                  - w_min, w_max
+                  - O_min (oscillations lower bound)
+                  - D_min (damping lower bound)
+                  - tc_min_days, tc_max_days
+                  - tc_min_frac, tc_max_frac
+
+                The critical-time condition is:
+                  max(t2 - tc_min_days, t2 - tc_min_frac * (t2 - t1))
+                  < tc <
+                  min(t2 + tc_max_days, t2 + tc_max_frac * (t2 - t1))
+
+                If None, the default thresholds used in previous versions
+                are applied.
 
         Returns:
             pd.DataFrame: A DataFrame with columns:
@@ -297,15 +354,20 @@ class LPPLS:
         ts = []
         _fits = []
 
-        if filter_conditions_config is None:
-            # TODO make configurable again!
-            m_min, m_max = (0.0, 1.0)
-            w_min, w_max = (2.0, 15.0)
-            O_min = 2.5
-            D_min = 0.5
-        else:
-            # TODO parse user provided conditions
-            pass
+        effective_config = (
+            self.filter_conditions_config
+            if filter_conditions_config is None
+            else filter_conditions_config
+        )
+        conditions = self._resolve_filter_conditions_config(effective_config)
+        m_min, m_max = conditions["m_min"], conditions["m_max"]
+        w_min, w_max = conditions["w_min"], conditions["w_max"]
+        O_min = conditions["O_min"]
+        D_min = conditions["D_min"]
+        tc_min_days = conditions["tc_min_days"]
+        tc_max_days = conditions["tc_max_days"]
+        tc_min_frac = conditions["tc_min_frac"]
+        tc_max_frac = conditions["tc_max_frac"]
 
         for r in res:
             ts.append(r["t2"])
@@ -342,9 +404,9 @@ class LPPLS:
                 # print('______________')
 
                 tc_in_range = (
-                    max(t2 - 60, t2 - 0.5 * (t2 - t1))
+                    max(t2 - tc_min_days, t2 - tc_min_frac * (t2 - t1))
                     < tc
-                    < min(t2 + 252, t2 + 0.5 * (t2 - t1))
+                    < min(t2 + tc_max_days, t2 + tc_max_frac * (t2 - t1))
                 )
                 m_in_range = m_min < m < m_max
                 w_in_range = w_min < w < w_max
@@ -407,16 +469,23 @@ class LPPLS:
         return res_df
         # return ts, price, pos_lst, neg_lst, pos_conf_lst, neg_conf_lst, #tc_lst, m_lst, w_lst, O_lst, D_lst
 
-    def plot_confidence_indicators(self, res: list[dict[str, Any]]) -> None:
+    def plot_confidence_indicators(
+        self,
+        res: list[dict[str, Any]],
+        filter_conditions_config: dict[str, Any] | None = None,
+    ) -> None:
         """
         Args:
             res (list): result from mp_compute_indicator
-            condition_name (str): the name you assigned to the filter condition in your config
-            title (str): super title for both subplots
+            filter_conditions_config (dict, optional): Custom indicator
+                thresholds. If None, uses the most recently stored config
+                from ``mp_compute_nested_fits`` (or the library defaults).
         Returns:
             nothing, should plot the indicator
         """
-        res_df = self.compute_indicators(res)
+        res_df = self.compute_indicators(
+            res, filter_conditions_config=filter_conditions_config
+        )
         fig, (ax1, ax2) = plt.subplots(nrows=2, ncols=1, sharex=True, figsize=(18, 10))
 
         ord = res_df["time"].astype("int32")
@@ -546,8 +615,10 @@ class LPPLS:
                 attempt when fitting the LPPLS model for each sub-window. The
                 literature suggests 25. Higher values improve the chance of
                 finding a good fit but increase computation time. Default: 25.
-            filter_conditions_config (dict): Reserved for future use.
-                Not implemented in 0.6.x.
+            filter_conditions_config (dict, optional): Indicator filter
+                thresholds for downstream calls to ``compute_indicators`` /
+                ``plot_confidence_indicators``. This method stores the
+                resolved config on the model instance.
 
         Returns:
             list[dict]: A list of result dicts, one per outer window position.
@@ -559,6 +630,9 @@ class LPPLS:
                     sub-window, each containing fitted parameters
                     (tc, m, w, a, b, c, c1, c2, t1, t2, O, D).
         """
+        self.filter_conditions_config = self._resolve_filter_conditions_config(
+            filter_conditions_config
+        )
         obs_copy = self.observations
         obs_opy_len = len(obs_copy[0]) - window_size
         func = self._func_compute_nested_fits

--- a/tests/test_lppls.py
+++ b/tests/test_lppls.py
@@ -278,6 +278,217 @@ def test_mp_compute_nested_fits(observations, lppls_model):
     assert set(res[0]["res"][0]).issubset(expected_keys)
 
 
+def test_compute_indicators_respects_custom_filter_config(lppls_model):
+    """Custom thresholds should change fit qualification and confidence."""
+    res = [
+        {
+            "t1": 0.0,
+            "t2": 100.0,
+            "p2": 10.0,
+            "res": [
+                {
+                    "tc": 120.0,
+                    "m": 0.5,
+                    "w": 8.0,
+                    "a": 1.0,
+                    "b": -1.0,
+                    "c": 1.0,
+                    "c1": 0.0,
+                    "c2": 0.0,
+                    "t1": 0.0,
+                    "t2": 100.0,
+                    "O": 3.0,
+                    "D": 0.8,
+                },
+                {
+                    "tc": 120.0,
+                    "m": 0.5,
+                    "w": 8.0,
+                    "a": 1.0,
+                    "b": -1.0,
+                    "c": 1.0,
+                    "c1": 0.0,
+                    "c2": 0.0,
+                    "t1": 0.0,
+                    "t2": 100.0,
+                    "O": 1.0,
+                    "D": 0.8,
+                },
+            ],
+        }
+    ]
+    default_df = lppls_model.compute_indicators(res)
+    assert default_df["pos_conf"].iloc[0] == pytest.approx(0.5)
+
+    custom_df = lppls_model.compute_indicators(res, {"O_min": 0.5})
+    assert custom_df["pos_conf"].iloc[0] == pytest.approx(1.0)
+
+
+def test_compute_indicators_invalid_filter_key_raises(lppls_model):
+    """Unknown filter keys should raise a ValueError."""
+    with pytest.raises(ValueError):
+        lppls_model.compute_indicators([], {"unknown_threshold": 1.0})
+
+
+# ---------------------------------------------------------------------------
+# filter_conditions_config resolution / validation
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_filter_conditions_config_none_returns_defaults():
+    """None should yield the full set of default thresholds."""
+    resolved = lppls.LPPLS._resolve_filter_conditions_config(None)
+    assert resolved == {
+        "m_min": 0.0,
+        "m_max": 1.0,
+        "w_min": 2.0,
+        "w_max": 15.0,
+        "O_min": 2.5,
+        "D_min": 0.5,
+        "tc_min_days": 60.0,
+        "tc_max_days": 252.0,
+        "tc_min_frac": 0.5,
+        "tc_max_frac": 0.5,
+    }
+
+
+def test_resolve_filter_conditions_config_merges_and_casts():
+    """Provided values override defaults and are coerced to float."""
+    resolved = lppls.LPPLS._resolve_filter_conditions_config({"O_min": 1, "D_min": 2})
+    assert resolved["O_min"] == 1.0
+    assert isinstance(resolved["O_min"], float)
+    assert resolved["D_min"] == 2.0
+    # Untouched keys keep their defaults.
+    assert resolved["m_max"] == 1.0
+
+
+def test_resolve_filter_conditions_config_non_dict_raises():
+    """A non-dict, non-None config should raise TypeError."""
+    with pytest.raises(TypeError):
+        lppls.LPPLS._resolve_filter_conditions_config([("O_min", 1.0)])
+
+
+@pytest.mark.parametrize(
+    "bad_config",
+    [
+        {"m_min": 1.0, "m_max": 0.0},
+        {"m_min": 0.5, "m_max": 0.5},
+        {"w_min": 15.0, "w_max": 2.0},
+        {"w_min": 5.0, "w_max": 5.0},
+        {"tc_min_days": -1.0},
+        {"tc_max_days": -1.0},
+        {"tc_min_frac": -0.1},
+        {"tc_max_frac": -0.1},
+    ],
+)
+def test_resolve_filter_conditions_config_invalid_ranges_raise(bad_config):
+    """Inconsistent or negative thresholds should raise ValueError."""
+    with pytest.raises(ValueError):
+        lppls.LPPLS._resolve_filter_conditions_config(bad_config)
+
+
+def _single_window_res(o_pos=3.0, b=-1.0, tc=120.0):
+    """Build a one-window nested-fit result with a single fit."""
+    return [
+        {
+            "t1": 0.0,
+            "t2": 100.0,
+            "p2": 10.0,
+            "res": [
+                {
+                    "tc": tc,
+                    "m": 0.5,
+                    "w": 8.0,
+                    "a": 1.0,
+                    "b": b,
+                    "c": 1.0,
+                    "c1": 0.0,
+                    "c2": 0.0,
+                    "t1": 0.0,
+                    "t2": 100.0,
+                    "O": o_pos,
+                    "D": 0.8,
+                }
+            ],
+        }
+    ]
+
+
+def test_compute_indicators_uses_stored_config(lppls_model):
+    """compute_indicators(None) should fall back to the stored instance config."""
+    res = _single_window_res(o_pos=1.0)
+    # With defaults (O_min=2.5) this fit fails the O condition.
+    assert lppls_model.compute_indicators(res)["pos_conf"].iloc[0] == pytest.approx(0.0)
+
+    # Storing a looser config (as mp_compute_nested_fits does) should be picked
+    # up when no explicit config is passed.
+    lppls_model.filter_conditions_config = (
+        lppls.LPPLS._resolve_filter_conditions_config({"O_min": 0.5})
+    )
+    assert lppls_model.compute_indicators(res)["pos_conf"].iloc[0] == pytest.approx(1.0)
+
+
+def test_compute_indicators_neg_conf_custom_config(lppls_model):
+    """Negative bubbles (b > 0) should be scored via neg_conf."""
+    res = _single_window_res(o_pos=1.0, b=1.0)
+    default_df = lppls_model.compute_indicators(res)
+    assert default_df["neg_conf"].iloc[0] == pytest.approx(0.0)
+    assert default_df["pos_conf"].iloc[0] == pytest.approx(0.0)
+
+    custom_df = lppls_model.compute_indicators(res, {"O_min": 0.5})
+    assert custom_df["neg_conf"].iloc[0] == pytest.approx(1.0)
+    assert custom_df["pos_conf"].iloc[0] == pytest.approx(0.0)
+
+
+def test_compute_indicators_tc_range_filtering(lppls_model):
+    """tc outside the configured critical-time window disqualifies a fit."""
+    # tc=400 is far beyond the default upper bound, so the fit fails.
+    res = _single_window_res(tc=400.0)
+    assert lppls_model.compute_indicators(res)["pos_conf"].iloc[0] == pytest.approx(0.0)
+
+    # Widening tc_max_days/tc_max_frac brings tc=400 into range.
+    widened = lppls_model.compute_indicators(
+        res, {"tc_max_days": 1000.0, "tc_max_frac": 5.0}
+    )
+    assert widened["pos_conf"].iloc[0] == pytest.approx(1.0)
+
+
+def test_mp_compute_nested_fits_stores_config(observations):
+    """mp_compute_nested_fits should resolve and persist the config."""
+    model = lppls.LPPLS(observations=observations)
+    assert model.filter_conditions_config is None
+    model.mp_compute_nested_fits(workers=1, filter_conditions_config={"O_min": 1.5})
+    assert model.filter_conditions_config["O_min"] == 1.5
+    # Defaults are still merged in for unspecified keys.
+    assert model.filter_conditions_config["m_max"] == 1.0
+
+
+def test_plot_confidence_indicators_forwards_config(lppls_model, monkeypatch):
+    """plot_confidence_indicators should forward its config to compute_indicators."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    captured = {}
+
+    def fake_compute_indicators(res, filter_conditions_config=None):
+        captured["config"] = filter_conditions_config
+        return pd.DataFrame(
+            {
+                "time": [738000.0],
+                "price": [1.0],
+                "pos_conf": [0.0],
+                "neg_conf": [0.0],
+            }
+        )
+
+    monkeypatch.setattr(lppls_model, "compute_indicators", fake_compute_indicators)
+
+    config = {"O_min": 0.5}
+    lppls_model.plot_confidence_indicators([], filter_conditions_config=config)
+    lppls.plt.close("all")
+    assert captured["config"] == config
+
+
 def test_detect_bubble_start_time_via_lagrange(observations, lppls_model):
     """Smoke test: Lagrange method runs without error and returns expected keys."""
     result = lppls_model.detect_bubble_start_time_via_lagrange(


### PR DESCRIPTION
## Summary

`filter_conditions_config` was previously accepted by the public API but ignored — indicator thresholds were hardcoded and the parameter was documented as "not implemented in 0.6.x". This PR wires it through end to end.

- Add `LPPLS._resolve_filter_conditions_config()` to validate and merge user thresholds with defaults (`m_min/m_max`, `w_min/w_max`, `O_min`, `D_min`, `tc_min_days/tc_max_days`, `tc_min_frac/tc_max_frac`). Raises `TypeError`/`ValueError` on bad input.
- `compute_indicators()` now uses the resolved config, including a configurable critical-time (`tc`) window, instead of hardcoded values.
- `mp_compute_nested_fits()` resolves and stores the config on the instance so downstream `compute_indicators` / `plot_confidence_indicators` calls reuse it; `plot_confidence_indicators()` also accepts an explicit override.
- Update README example to show a real `filter_conditions_config`.

## Test plan

- [x] `test_resolve_filter_conditions_config_*` — defaults, merge/cast, non-dict `TypeError`, invalid/negative ranges raise
- [x] `test_compute_indicators_respects_custom_filter_config` / `_uses_stored_config` — explicit + stored-config fallback
- [x] `test_compute_indicators_neg_conf_custom_config` / `_tc_range_filtering` — neg path and tc-window filtering
- [x] `test_mp_compute_nested_fits_stores_config` — config persisted on instance
- [x] `test_plot_confidence_indicators_forwards_config` — config forwarded to `compute_indicators`
- [x] Full suite: `39 passed`

Made with [Cursor](https://cursor.com)