### PR TITLE
ci: add ZT-Slop zero-trust PR check

### DIFF
--- a/.github/workflows/zt-slop.yml
+++ b/.github/workflows/zt-slop.yml
@@ -1,0 +1,21 @@
+name: ZT-Slop
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: Joshwani/zt-slop@v0
+        with:
+          fail-on: block


### PR DESCRIPTION
## Summary

Adds the [ZT-Slop](https://github.com/Joshwani/zt-slop) zero-trust PR check as a GitHub Actions workflow. It runs on every pull request and flags high-signal, PR-introduced supply-chain risk without executing PR code.

What it scans (diff-first):
- Known malicious npm/PyPI packages (OSV advisories)
- Lockfile source drift (non-registry URLs, `git+ssh`, `file:`, etc.)
- GitHub Actions privilege drift (`pull_request_target`, `permissions: write-all`)
- Secret-exfiltration paths and obvious leaked secrets/keys
- Install-time execution hooks (`preinstall`/`postinstall`/`prepare`)

Configured with `fail-on: block` and least-privilege `contents: read` permissions, checked out with `persist-credentials: false`.

## Test plan

- [x] Confirm the `ZT-Slop` check appears and runs on this PR
- [x] Verify it passes (no supply-chain findings in this diff)