### PR TITLE
ci: skip already-published versions on PyPI upload

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -28,4 +28,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+        twine upload --skip-existing dist/*


### PR DESCRIPTION
## Summary

The PyPI publish workflow triggers on every push to `master`, not just version bumps. Merges that don't change the version (e.g. the recent ZT-Slop CI addition) fail at `twine upload` with "File already exists", showing a red ❌ even though the package is already published correctly.

This adds `--skip-existing` so the upload step succeeds and only publishes genuinely new versions.

```
twine upload --skip-existing dist/*
```

## Test plan

- [ ] Merge and confirm the `PyPI 📦` job is green even though `0.6.24` already exists on PyPI
- [ ] Next real version bump still publishes as expected